### PR TITLE
Handle long list items, complete with settings

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -47,5 +47,27 @@ export class SummarySettingTab extends PluginSettingTab {
                 await this.plugin.saveSettings();
             })
         );
+        new Setting(containerEl)
+        .setName("List Items As Paragraphs")
+        .setDesc("Treat list items as a individual paragraphs, and only include the items that contains the tag")
+        .addToggle((toggle) =>
+            toggle
+            .setValue(this.plugin.settings.listparagraph)
+            .onChange(async (value) => {
+                this.plugin.settings.listparagraph = value;
+                await this.plugin.saveSettings();
+            })
+        );
+        new Setting(containerEl)
+        .setName("Include Child List Items")
+        .setDesc("Also include child items of a list item.")
+        .addToggle((toggle) =>
+            toggle
+            .setValue(this.plugin.settings.includechildren)
+            .onChange(async (value) => {
+                this.plugin.settings.includechildren = value;
+                await this.plugin.saveSettings();
+            })
+        );
     }
 }


### PR DESCRIPTION
Thank you for the very useful plugin!

This pull request addresses #9 . Originally, a long list is treated as a single paragraph, as there are usually no empty lines between list items. 

To solve this problem, I've added code to iterate through the lines and pick out list items by checking for the starting "- ". The items are again checked for tags the same way paragraphs are checked, and only added to the summary if it passes the test. I've also added an option to include the child items.

Two new settings ("List Items As Paragraphs" and "Include Child List Items") are also added. With the two settings disabled, the plugin functions the same as before. 