### PR TITLE
Simplify Link, Make Callouts Collapsible

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -260,7 +260,7 @@ export default class SummaryPlugin extends Plugin {
 					rows.forEach((row) => {
 						callout += "> " + row + "\n";
 					});
-					paragraph = callout + "\n\n---\n\n";
+					paragraph = callout + "\n\n";
 				} else {
 					// No Callout
 					paragraph += "\n\n";

--- a/main.ts
+++ b/main.ts
@@ -249,7 +249,7 @@ export default class SummaryPlugin extends Plugin {
 
 				// Add link to original note
 				if (this.settings.includelink) {
-					paragraph = "[[" + filePath + "|🔗]] " + paragraph;
+					paragraph = "[[" + filePath + "|🔗]]" + paragraph;
 				}
 
 				// Insert the text in a callout

--- a/main.ts
+++ b/main.ts
@@ -249,18 +249,18 @@ export default class SummaryPlugin extends Plugin {
 
 				// Add link to original note
 				if (this.settings.includelink) {
-					paragraph = "**Source:** [[" + filePath + "|" + fileName + "]]\n" + paragraph;
+					paragraph = "[[" + filePath + "|🔗]] " + paragraph;
 				}
 
 				// Insert the text in a callout
 				if (this.settings.includecallout) {
 					// Insert the text in a callout box
-					let callout = "> [!" + fileName + "]\n";
+					let callout = "> [!" + fileName + "]+\n";
 					const rows = paragraph.split("\n");
 					rows.forEach((row) => {
 						callout += "> " + row + "\n";
 					});
-					paragraph = callout + "\n\n";
+					paragraph = callout + "\n\n---\n\n";
 				} else {
 					// No Callout
 					paragraph += "\n\n";


### PR DESCRIPTION
When both the callout and link options are on, the filename gets repeated and it makes it more cluttered.

This way, someone can turn on the link which is (now a "🔗" emoji without the line break), and if they want to view the filename, they can turn on callouts like so:

![compact](https://user-images.githubusercontent.com/85248647/230422929-32c75250-7026-4464-96fb-1f685e2cf2e1.png)

![callout](https://user-images.githubusercontent.com/85248647/230422954-9aa3865c-a2d6-4cd9-8390-9fab0cc78a42.png)

I also found that collapsible callouts are useful when viewing large summaries.